### PR TITLE
Fix: Fixed Environment Variable Key for Noticeboard API Request

### DIFF
--- a/client-side/src/pages/Noticeboard/Noticeboard.jsx
+++ b/client-side/src/pages/Noticeboard/Noticeboard.jsx
@@ -44,12 +44,8 @@ export default function NoticeBoard() {
   const updatePageHtml = async () => {
 
     try {
-      const NoticeboardAPIresponse = await axios.get(process.env.REACT_APP_SERVER_PATH + '/noticeboard');
+      const NoticeboardAPIresponse = await axios.get(process.env.REACT_APP_SERVER_BASE_URL + '/noticeboard');
       const noticeList = NoticeboardAPIresponse.data.data;
-
-      // data is loaded.
-      console.log(noticeList);
-
 
       setPageHtml(<>
         <div>


### PR DESCRIPTION
# Fix Environment Variable Key for Noticeboard API Request
[ Fixes #62 ]

## Description
Updated the environment variable from `REACT_APP_SERVER_PATH` to `REACT_APP_SERVER_BASE_URL` in the `updatePageHtml` function for the Noticeboard API request.

## Checklist
- [x] Fixed environment variable key.
